### PR TITLE
Support Item->ItemId

### DIFF
--- a/classes/EbayOrder.php
+++ b/classes/EbayOrder.php
@@ -927,7 +927,7 @@ class EbayOrder
                 if (!$product_has_find && false) {
                     //Not possible with ebay multivariation products to retrieve the correct product
                     if (!isset($transaction->Variation->SKU)) {
-                        if ($p = EbayProduct::getProductsIdFromItemId($transaction->Item->ID)) {
+                        if ($p = EbayProduct::getProductsIdFromItemId($transaction->Item->ID ?? $transaction->Item->ItemId)) {
                             $products[] = array(
                                 'id_product'           => $p['id_product'],
                                 'id_product_attribute' => $p['id_product_attribute'],


### PR DESCRIPTION
It seems `ItemID` is used in eBay responses.
I don't know whether this is a long dating bug or if it's quite specific but eBay uses `ItemID` in my responses which leaded to a non-working orders sync.